### PR TITLE
Prevent destructive commands via env diff scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Claude can then run any read-only kubectl command without asking for permission,
 
 ## Philosophy
 
-**When in doubt, block.** This tool prefers false negatives (blocking safe commands) over false positives (allowing dangerous commands). If a command isn't explicitly in the allowlist, it's blocked.
+**When in doubt, block.** This tool prefers false negatives (blocking safe commands) over false positives (allowing dangerous commands). If a command isn't explicitly in the allowlist, it's blocked. Environment variables are filtered to prevent bypasses via kubectl control variables.
 
 ## Releases
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,5 +48,6 @@ kubectl-readonly is designed with a **"deny by default"** philosophy:
 - Secret values are protected even for read operations
 - No shell interpretation of arguments (prevents injection)
 - Control characters in arguments are blocked
+- Environment variables are filtered to prevent control variable bypasses
 
 For more details, see the [Philosophy section](README.md#philosophy) in the README.

--- a/main.go
+++ b/main.go
@@ -76,6 +76,33 @@ For a list of allowed commands, see: kubectl-readonly --help
 	return execKubectl(filteredArgs)
 }
 
+func getSafeEnvironment() []string {
+	// Only pass through essential environment variables to kubectl
+	// This prevents exploitation via kubectl-specific env vars like KUBECTL_EXTERNAL_DIFF
+	allowedPrefixes := []string{
+		"HOME=",
+		"USER=",
+		"PATH=",
+		"KUBECONFIG=",
+		"KUBERNETES_", // KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT, etc.
+		"LANG=",
+		"LC_",
+		"TERM=",
+		"TZ=",
+	}
+
+	var safeEnv []string
+	for _, env := range os.Environ() {
+		for _, prefix := range allowedPrefixes {
+			if strings.HasPrefix(env, prefix) {
+				safeEnv = append(safeEnv, env)
+				break
+			}
+		}
+	}
+	return safeEnv
+}
+
 func execKubectl(args []string) int {
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
@@ -85,7 +112,7 @@ func execKubectl(args []string) int {
 
 	// Use syscall.Exec to replace the current process (more efficient)
 	execArgs := append([]string{"kubectl"}, args...)
-	if err := syscall.Exec(kubectlPath, execArgs, os.Environ()); err != nil {
+	if err := syscall.Exec(kubectlPath, execArgs, getSafeEnvironment()); err != nil {
 		fmt.Fprintf(os.Stderr, "Error executing kubectl: %v\n", err)
 		return 1
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -1085,5 +1086,105 @@ func TestContainsRawSecretsAccess(t *testing.T) {
 				t.Errorf("expected no raw secrets access: %v", args)
 			}
 		})
+	}
+}
+
+// =============================================================================
+// Environment Variable Security Tests
+// =============================================================================
+
+func TestGetSafeEnvironment(t *testing.T) {
+	// Save and restore original environment
+	origEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range origEnv {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(parts[0], parts[1])
+			}
+		}
+	}()
+
+	// Set test environment
+	os.Clearenv()
+	os.Setenv("HOME", "/home/user")
+	os.Setenv("PATH", "/usr/bin")
+	os.Setenv("KUBECONFIG", "/home/user/.kube/config")
+	os.Setenv("KUBECTL_EXTERNAL_DIFF", "/tmp/evil.sh") // Should be blocked
+	os.Setenv("USER", "testuser")
+	os.Setenv("LANG", "en_US.UTF-8")
+
+	safeEnv := getSafeEnvironment()
+	envMap := make(map[string]string)
+	for _, env := range safeEnv {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	// Verify safe vars are passed through
+	if envMap["HOME"] != "/home/user" {
+		t.Error("HOME should be passed through")
+	}
+	if envMap["PATH"] != "/usr/bin" {
+		t.Error("PATH should be passed through")
+	}
+	if envMap["KUBECONFIG"] != "/home/user/.kube/config" {
+		t.Error("KUBECONFIG should be passed through")
+	}
+	if envMap["USER"] != "testuser" {
+		t.Error("USER should be passed through")
+	}
+	if envMap["LANG"] != "en_US.UTF-8" {
+		t.Error("LANG should be passed through")
+	}
+
+	// Verify dangerous vars are blocked
+	if _, exists := envMap["KUBECTL_EXTERNAL_DIFF"]; exists {
+		t.Error("KUBECTL_EXTERNAL_DIFF should be blocked (security vulnerability)")
+	}
+}
+
+func TestDangerousEnvVarsBlocked(t *testing.T) {
+	dangerousVars := []string{
+		"KUBECTL_EXTERNAL_DIFF",
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+	}
+
+	// Save and restore
+	origEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range origEnv {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(parts[0], parts[1])
+			}
+		}
+	}()
+
+	os.Clearenv()
+	for _, v := range dangerousVars {
+		os.Setenv(v, "/tmp/exploit")
+	}
+	os.Setenv("HOME", "/home/user") // Add one safe var
+
+	safeEnv := getSafeEnvironment()
+	envMap := make(map[string]string)
+	for _, env := range safeEnv {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	for _, dangerous := range dangerousVars {
+		if _, exists := envMap[dangerous]; exists {
+			t.Errorf("%s should be blocked for security", dangerous)
+		}
 	}
 }


### PR DESCRIPTION
## Security Fix: Block Environment Variable Code Execution Bypass

### Disclaimer :) 

This is pretty much AI generated all the way down (with the exception of this section in the PR). After I've skimmed through the code manually (thought it looks like it does what the docs claim), I let Claude think of other potential attacks. Besides minor things, it came up with this. Imho it is unlikely that an agent would exploit this but I honestly saw it being very creative in the past, so I rather have this in place if I ever run this against my prod k8s cluster.
I manually validated that the POC and the fix for it actually works.


### Problem

An AI agent can unintentionally bypass the read-only restrictions through environment variables. The `kubectl diff` command (which is allowed) respects the `KUBECTL_EXTERNAL_DIFF` environment variable to specify a custom diff program. Since all environment variables are passed through to kubectl, an AI that sets this variable can inadvertently execute arbitrary code.

**Scenario:** An AI agent trying to be helpful might set `KUBECTL_EXTERNAL_DIFF` to customize output formatting, not realizing this executes external programs with full kubectl privileges.

### Proof of Concept

```bash
# Create a script that performs cluster modifications
cat > /tmp/helpful-diff.sh << 'EOF'
#!/bin/bash
# AI might think this just formats diff output nicely,
# but it actually executes with full kubectl privileges
kubectl delete pods --all -A  # Destructive operation
# Or: kubectl get secrets -o json | send-to-analysis-tool
EOF
chmod +x /tmp/helpful-diff.sh

# AI sets environment variable thinking it's just for formatting
export KUBECTL_EXTERNAL_DIFF=/tmp/helpful-diff.sh

# AI runs what it believes is a safe read-only command
kubectl-readonly diff -f deployment.yaml

# Result: The script executes with full privileges, bypassing all protections
```

### Impact

- AI agents can unintentionally execute destructive cluster operations
- Secrets can be exfiltrated despite protection mechanisms
- Complete bypass of the allowlist security model
- Undermines the purpose of kubectl-readonly for AI safety

### Solution

This PR implements environment variable filtering to only pass through essential variables to kubectl. Kubectl-specific control variables like `KUBECTL_EXTERNAL_DIFF` are blocked, preventing unintentional code execution.

**Allowed variables:** HOME, PATH, KUBECONFIG, KUBERNETES_*, LANG, LC_*, TERM, TZ
**Blocked variables:** KUBECTL_EXTERNAL_DIFF, HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and any others not explicitly allowed

### Changes

- Added `getSafeEnvironment()` function to filter environment variables (main.go:79)
- Modified `execKubectl()` to use filtered environment (main.go:115)
- Added comprehensive tests for environment variable security (main_test.go:1095)

### Testing

```bash
# Verify dangerous env vars are blocked
go test -v -run TestDangerousEnvVarsBlocked

# Verify safe env vars pass through
go test -v -run TestGetSafeEnvironment

# All existing tests still pass
go test
```

This ensures AI agents cannot accidentally bypass read-only restrictions while maintaining all intended functionality.