### PR TITLE
feat: extract kubepolicy library and expand allowed commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ coverage.out
 
 # OS
 .DS_Store
+
+# Implementation plans (local only)
+docs/plans/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ If you try a command that's not read-only, it will be blocked:
 $ kubectl-readonly delete pod my-pod
 This command is not safe for read-only access; use kubectl directly instead.
 
-Reason: Command 'delete' is not in the read-only allowlist
+kubectl-readonly only allows read-only commands without side effects.
+For a list of allowed commands, see: kubectl-readonly --help
 ```
 
 ### Check mode
@@ -88,7 +89,7 @@ $ kubectl-readonly --readonly-check-ok get pods
 OK: This command is allowed by kubectl-readonly
 
 $ kubectl-readonly --readonly-check-ok delete pod my-pod
-BLOCKED: Command 'delete' is not in the read-only allowlist
+BLOCKED: This command is not allowed in read-only mode
 ```
 
 ## Allowed Commands
@@ -109,14 +110,27 @@ BLOCKED: Command 'delete' is not in the read-only allowlist
 | `events` | View cluster events |
 | `wait` | Wait for a condition |
 | `diff` | Show differences without applying |
+| `kustomize` | Render kustomize manifests locally (restricted, see below) |
 
 ### Commands with specific subcommands
 
 | Command | Allowed subcommands |
 |---------|---------------------|
-| `config` | `view`, `get-contexts`, `current-context`, `use-context` |
+| `config` | `view`, `get-contexts`, `get-clusters`, `get-users`, `current-context`, `use-context` |
 | `auth` | `can-i`, `whoami` |
 | `rollout` | `status`, `history` |
+| `krew` | `list`, `search`, `info` |
+
+## Kustomize Restrictions
+
+The `kustomize` command is allowed for local manifest rendering, but the following flags are blocked because they enable code execution, network access, or unrestricted file reads:
+
+| Blocked flag | Risk |
+|---|---|
+| `--enable-alpha-plugins` | Executes arbitrary local binaries |
+| `--enable-helm` | Invokes helm (may fetch remote charts) |
+| `--network` | Enables network access for functions |
+| `--load-restrictor=None` | Allows reading files outside the kustomization root |
 
 ## Secrets Protection
 

--- a/kubepolicy/check.go
+++ b/kubepolicy/check.go
@@ -1,0 +1,54 @@
+// Package kubepolicy provides a read-only policy check for kubectl commands.
+//
+// It implements a deny-by-default allowlist: only commands explicitly listed
+// as safe are permitted. Secret values are protected by blocking output formats
+// that expose base64-decoded data.
+package kubepolicy
+
+// Check reports whether the given kubectl arguments are allowed
+// under a read-only policy.
+func Check(args []string) bool {
+	if len(args) == 0 {
+		return true // allow: bare kubectl invocation shows help
+	}
+
+	if containsControlCharacters(args) {
+		return false // deny: potential injection via control characters
+	}
+
+	command, subcommand := extractCommandAndSubcommand(args)
+	if command == "" {
+		return true // deny: only flags, no command — harmless
+	}
+
+	// Safe commands (no subcommand validation needed).
+	if safeCommands[command] {
+		if containsSecretResource(args) {
+			if isSecretExposingFormat(getOutputFormat(args)) {
+				return false // deny: output format exposes secret values
+			}
+		}
+		if containsRawSecretsAccess(args) {
+			return false // deny: --raw access to secrets API
+		}
+		if command == "kustomize" {
+			if containsBlockedKustomizeFlags(args) {
+				return false // deny: kustomize flag enables execution/network/unrestricted reads
+			}
+		}
+		return true
+	}
+
+	// Commands requiring a specific subcommand.
+	if allowedSubs, ok := safeSubcommands[command]; ok {
+		if subcommand == "" {
+			return false // deny: command requires a subcommand
+		}
+		if allowedSubs[subcommand] {
+			return true
+		}
+		return false // deny: subcommand not in allowlist
+	}
+
+	return false // deny: command not in any allowlist
+}

--- a/kubepolicy/check_test.go
+++ b/kubepolicy/check_test.go
@@ -1,22 +1,20 @@
-package main
+package kubepolicy
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/Evaneos/kubectl-readonly/kubepolicy"
 )
 
 func assertAllowed(t *testing.T, args []string) {
 	t.Helper()
-	if !kubepolicy.Check(args) {
+	if !Check(args) {
 		t.Errorf("expected allowed, got blocked (args: %v)", args)
 	}
 }
 
 func assertBlocked(t *testing.T, args []string) {
 	t.Helper()
-	if kubepolicy.Check(args) {
+	if Check(args) {
 		t.Errorf("expected blocked, got allowed (args: %v)", args)
 	}
 }
@@ -26,13 +24,11 @@ func assertBlocked(t *testing.T, args []string) {
 // =============================================================================
 
 func TestSafeCommands(t *testing.T) {
-	safeCommandsList := []string{
+	for _, cmd := range []string{
 		"get", "describe", "logs", "top", "explain",
 		"api-resources", "api-versions", "cluster-info", "version", "events", "wait", "diff",
 		"kustomize",
-	}
-
-	for _, cmd := range safeCommandsList {
+	} {
 		t.Run(cmd, func(t *testing.T) {
 			assertAllowed(t, []string{cmd, "pods"})
 		})
@@ -40,16 +36,14 @@ func TestSafeCommands(t *testing.T) {
 }
 
 func TestDangerousCommands(t *testing.T) {
-	dangerousCmds := []string{
+	for _, cmd := range []string{
 		"delete", "create", "apply", "patch", "edit", "replace",
 		"exec", "run", "attach", "cp",
 		"scale", "autoscale",
 		"cordon", "uncordon", "drain", "taint",
 		"label", "annotate",
 		"port-forward", "proxy",
-	}
-
-	for _, cmd := range dangerousCmds {
+	} {
 		t.Run(cmd, func(t *testing.T) {
 			assertBlocked(t, []string{cmd, "pods"})
 		})
@@ -69,7 +63,6 @@ func TestSafeSubcommands(t *testing.T) {
 		{"rollout", "status", "deployment/nginx"},
 		{"rollout", "history", "deployment/nginx"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0]+"-"+args[1], func(t *testing.T) {
 			assertAllowed(t, args)
@@ -79,22 +72,18 @@ func TestSafeSubcommands(t *testing.T) {
 
 func TestDangerousSubcommands(t *testing.T) {
 	tests := [][]string{
-		// Dangerous rollout subcommands
 		{"rollout", "restart", "deployment/nginx"},
 		{"rollout", "undo", "deployment/nginx"},
 		{"rollout", "pause", "deployment/nginx"},
 		{"rollout", "resume", "deployment/nginx"},
-		// Dangerous config subcommands
 		{"config", "set-context", "evil"},
 		{"config", "set-cluster", "evil"},
 		{"config", "set-credentials", "evil"},
 		{"config", "delete-context", "production"},
 		{"config", "delete-cluster", "production"},
 		{"config", "unset", "current-context"},
-		// Dangerous auth subcommands
 		{"auth", "reconcile", "-f", "evil.yaml"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0]+"-"+args[1], func(t *testing.T) {
 			assertBlocked(t, args)
@@ -123,10 +112,8 @@ func TestFlagsBeforeCommand(t *testing.T) {
 		{[]string{"--namespace=delete", "get", "pods"}, true},
 		{[]string{"--context=exec", "get", "pods"}, true},
 	}
-
 	for _, tt := range tests {
-		name := strings.Join(tt.args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
 			if tt.allowed {
 				assertAllowed(t, tt.args)
 			} else {
@@ -142,28 +129,22 @@ func TestFlagsBeforeCommand(t *testing.T) {
 
 func TestSecretsMetadataAllowed(t *testing.T) {
 	tests := [][]string{
-		// Basic listing
 		{"get", "secrets"},
 		{"get", "secret"},
 		{"get", "secrets", "--all-namespaces"},
 		{"get", "secrets", "-A"},
 		{"get", "secrets", "-n", "kube-system"},
 		{"get", "secrets", "--show-labels"},
-		// Flags before command
 		{"-n", "default", "get", "secrets"},
 		{"--context=prod", "get", "secrets"},
-		// Describe
 		{"describe", "secret", "my-secret"},
 		{"describe", "secrets"},
-		// Safe output formats
 		{"get", "secrets", "-o", "name"},
 		{"get", "secrets", "-o", "wide"},
 		{"get", "secret", "my-secret", "-o", "name"},
-		// Case variations
 		{"get", "SECRETS"},
 		{"get", "Secret"},
 		{"get", "Secrets"},
-		// API group qualified resource types (metadata only)
 		{"get", "secret.v1"},
 		{"get", "secrets.v1"},
 		{"get", "secret.core"},
@@ -172,10 +153,8 @@ func TestSecretsMetadataAllowed(t *testing.T) {
 		{"get", "secret.v1", "-o", "name"},
 		{"get", "secret.v1", "-o", "wide"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
@@ -183,49 +162,37 @@ func TestSecretsMetadataAllowed(t *testing.T) {
 
 func TestSecretsValuesBlocked(t *testing.T) {
 	tests := [][]string{
-		// YAML exposes .data field
 		{"get", "secrets", "-o", "yaml"},
 		{"get", "secret", "my-secret", "-o", "yaml"},
 		{"get", "secret/my-secret", "-o", "yaml"},
-		// JSON exposes .data field
 		{"get", "secrets", "-o", "json"},
 		{"get", "secret", "my-secret", "-o", "json"},
-		// Compact forms
 		{"get", "secrets", "-ojson"},
 		{"get", "secrets", "-oyaml"},
-		// jsonpath can extract .data
 		{"get", "secrets", "-o", "jsonpath={.data}"},
 		{"get", "secret", "my-secret", "-o", "jsonpath={.items[*].data}"},
 		{"get", "secrets", "-o", "jsonpath-as-json={.data}"},
-		// go-template can extract data
 		{"get", "secrets", "-o", "go-template={{.data}}"},
 		{"get", "secrets", "-o", "go-template-file=template.txt"},
-		// template format
 		{"get", "secrets", "-o", "template", "--template={{.data}}"},
 		{"get", "secrets", "-o", "templatefile=template.txt"},
-		// Comma-separated resources with secrets
 		{"get", "pods,secrets", "-o", "yaml"},
 		{"get", "secrets,pods", "-o", "json"},
 		{"get", "configmaps,secrets,pods", "-o", "yaml"},
-		// custom-columns can extract .data
 		{"get", "secrets", "-o", "custom-columns=DATA:.data"},
 		{"get", "secret", "my-secret", "-o", "custom-columns=NAME:.metadata.name,DATA:.data"},
 		{"get", "secrets", "-o", "custom-columns-file=columns.txt"},
-		// API group qualified resource types
 		{"get", "secret.v1", "-o", "yaml"},
 		{"get", "secrets.v1", "-o", "json"},
 		{"get", "secret.core", "-o", "yaml"},
 		{"get", "secret.v1.core", "-o", "yaml"},
 		{"get", "secrets.v1.core", "-o", "json"},
 		{"get", "secret.v1/my-secret", "-o", "yaml"},
-		// Comma-separated with API group qualifiers
 		{"get", "pods,secret.v1", "-o", "yaml"},
 		{"get", "secret.core,configmaps", "-o", "json"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
@@ -238,14 +205,11 @@ func TestSecretsRawBlocked(t *testing.T) {
 		{"get", "--raw=/api/v1/secrets"},
 		{"get", "--raw=/api/v1/namespaces/kube-system/secrets"},
 		{"get", "--raw", "/api/v1/namespaces/default/secrets/my-secret"},
-		// Case variations
 		{"get", "--raw", "/api/v1/SECRETS"},
 		{"get", "--raw", "/api/v1/Secrets"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
@@ -259,19 +223,15 @@ func TestSecretsRawNonSensitiveAllowed(t *testing.T) {
 		{"get", "--raw", "/healthz"},
 		{"get", "--raw", "/api/v1/configmaps"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
 func TestSecretsWithImpersonation(t *testing.T) {
-	// Impersonation doesn't bypass secrets value blocking
 	assertBlocked(t, []string{"get", "secrets", "-o", "yaml", "--as=system:admin"})
-	// Impersonation allows secrets metadata
 	assertAllowed(t, []string{"get", "secrets", "--as=system:admin"})
 }
 
@@ -285,40 +245,32 @@ func TestConfigMapsAllowed(t *testing.T) {
 		{"describe", "configmap", "my-config"},
 		{"get", "configmaps", "-o", "jsonpath={.data}"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
 func TestSecretsBypassAttempts(t *testing.T) {
-	blockedTests := [][]string{
-		// Different flag orderings
+	tests := [][]string{
 		{"-o", "yaml", "get", "secrets"},
 		{"get", "-o", "yaml", "secrets"},
 		{"get", "secrets", "-n", "default", "-o", "yaml"},
-		// With other flags
 		{"get", "secrets", "-o", "yaml", "--show-labels"},
 		{"get", "secrets", "-o", "json", "-l", "app=test"},
 		{"get", "secrets", "--output=yaml"},
 		{"get", "secrets", "--output", "yaml"},
-		// Type/name format
 		{"get", "secret/my-secret", "-o", "yaml"},
 		{"get", "secret/my-secret", "-o", "json"},
 		{"get", "secret/a", "secret/b", "-o", "yaml"},
-		// API group qualified bypass attempts
 		{"get", "secret.v1", "-o", "yaml"},
 		{"get", "secret.core", "-o", "json"},
 		{"get", "secret.v1.core", "-o", "yaml"},
 		{"get", "secret.v1/my-secret", "-o", "yaml"},
 	}
-
-	for _, args := range blockedTests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
@@ -340,60 +292,44 @@ func TestOutputFormatParsing(t *testing.T) {
 		{"get", "secrets", "--output=name"},
 		{"get", "secrets", "-o", "wide"},
 	}
-
 	for _, args := range blocked {
-		name := "blocked_" + strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run("blocked_"+strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
 	for _, args := range allowed {
-		name := "allowed_" + strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run("allowed_"+strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
 // =============================================================================
-// Security Bypass Tests - Shell Metacharacters
+// Security Bypass Tests
 // =============================================================================
 
 func TestShellMetacharactersInArgs(t *testing.T) {
-	// These are safe because Go doesn't use shell interpretation
 	tests := [][]string{
-		// Semicolon command chaining
 		{"get", "pods;", "delete", "pods"},
 		{"get", "pods;delete", "pods"},
 		{"get", "pods", ";", "delete", "pods"},
-		// Pipe command chaining
 		{"get", "pods|delete", "pods"},
 		{"get", "pods", "|", "delete", "pods"},
-		// AND operator
 		{"get", "pods&&delete", "pods"},
 		{"get", "pods", "&&", "delete", "pods"},
-		// OR operator
 		{"get", "pods||delete", "pods"},
 		{"get", "pods", "||", "delete", "pods"},
-		// Backtick command substitution
 		{"get", "`delete pods`"},
 		{"get", "pods", "`rm -rf /`"},
-		// $() command substitution
 		{"get", "$(delete pods)"},
 		{"get", "pods", "$(rm -rf /)"},
 		{"get", "${delete}", "pods"},
-		// Newline injection
 		{"get", "pods\ndelete", "pods"},
 		{"get", "pods\n", "delete", "pods"},
-		// Carriage return injection
 		{"get", "pods\rdelete", "pods"},
 	}
-
 	for _, args := range tests {
-		name := "safe_" + args[0]
-		t.Run(name, func(t *testing.T) {
-			// Command is "get", which is allowed
-			// Shell metacharacters are just literal strings
+		t.Run("safe_"+args[0], func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
@@ -410,7 +346,6 @@ func TestShellMetacharactersAsCommand(t *testing.T) {
 		{"get\ndelete", "pods"},
 		{"get\r\ndelete", "pods"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0], func(t *testing.T) {
 			assertBlocked(t, args)
@@ -418,28 +353,19 @@ func TestShellMetacharactersAsCommand(t *testing.T) {
 	}
 }
 
-// =============================================================================
-// Security Bypass Tests - Unicode and Encoding
-// =============================================================================
-
 func TestUnicodeHomoglyphs(t *testing.T) {
 	tests := [][]string{
-		// Unicode homoglyphs for 'delete'
-		{"d\u0435lete", "pods"}, // Cyrillic 'е' instead of Latin 'e'
-		{"\u0064elete", "pods"}, // Unicode escape (this is actually 'd')
-		{"dеlеtе", "pods"},      // Multiple Cyrillic letters
-		// Unicode homoglyphs for 'exec'
-		{"ехес", "pod"},      // Cyrillic
-		{"e\u0445ec", "pod"}, // Cyrillic х
-		// Full-width characters
-		{"\uff44elete", "pods"}, // Full-width 'd'
-		// Zero-width characters
-		{"del\u200bete", "pods"}, // Zero-width space
-		{"de\u200clete", "pods"}, // Zero-width non-joiner
-		{"del\u200dete", "pods"}, // Zero-width joiner
-		{"del\ufeffete", "pods"}, // BOM character
+		{"d\u0435lete", "pods"},
+		{"\u0064elete", "pods"},
+		{"dеlеtе", "pods"},
+		{"ехес", "pod"},
+		{"e\u0445ec", "pod"},
+		{"\uff44elete", "pods"},
+		{"del\u200bete", "pods"},
+		{"de\u200clete", "pods"},
+		{"del\u200dete", "pods"},
+		{"del\ufeffete", "pods"},
 	}
-
 	for _, args := range tests {
 		t.Run("unicode_homoglyph", func(t *testing.T) {
 			assertBlocked(t, args)
@@ -449,19 +375,16 @@ func TestUnicodeHomoglyphs(t *testing.T) {
 
 func TestCaseSensitivity(t *testing.T) {
 	tests := [][]string{
-		// Mixed case commands
 		{"GET", "pods"},
 		{"Get", "pods"},
 		{"DELETE", "pods"},
 		{"Delete", "pods"},
 		{"EXEC", "pod"},
 		{"Exec", "pod"},
-		// Config subcommands with case
 		{"CONFIG", "view"},
 		{"config", "VIEW"},
 		{"Config", "View"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0], func(t *testing.T) {
 			assertBlocked(t, args)
@@ -475,11 +398,9 @@ func TestNullByteInjection(t *testing.T) {
 		{"get", "pods\x00; rm -rf /"},
 		{"\x00delete", "pods"},
 		{"delete\x00", "pods"},
-		// Other special bytes
 		{"get\x01", "pods"},
-		{"get\x7f", "pods"}, // DEL character
+		{"get\x7f", "pods"},
 	}
-
 	for _, args := range tests {
 		t.Run("nullbyte", func(t *testing.T) {
 			assertBlocked(t, args)
@@ -487,25 +408,18 @@ func TestNullByteInjection(t *testing.T) {
 	}
 }
 
-// =============================================================================
-// Security Bypass Tests - Argument Confusion
-// =============================================================================
-
 func TestDoubleDashAttacks(t *testing.T) {
 	tests := []struct {
 		args    []string
 		allowed bool
 	}{
-		// Double-dash tricks - trying to smuggle commands after --
-		{[]string{"get", "pods", "--", "delete", "pods"}, true}, // get is command
-		{[]string{"get", "--", "delete"}, true},                 // get is command
-		{[]string{"--", "delete", "pods"}, false},               // delete is command
+		{[]string{"get", "pods", "--", "delete", "pods"}, true},
+		{[]string{"get", "--", "delete"}, true},
+		{[]string{"--", "delete", "pods"}, false},
 		{[]string{"--namespace=default", "--", "delete", "pods"}, false},
 	}
-
 	for _, tt := range tests {
-		name := strings.Join(tt.args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
 			if tt.allowed {
 				assertAllowed(t, tt.args)
 			} else {
@@ -519,13 +433,11 @@ func TestFlagInjection(t *testing.T) {
 	tests := [][]string{
 		{"get", "pods", "--output=yaml", "--dry-run=server"},
 		{"get", "pods", "-o", "yaml"},
-		{"logs", "pod", "--exec=whoami"},   // Fake flag
-		{"get", "pods", "--run=malicious"}, // Fake flag
+		{"logs", "pod", "--exec=whoami"},
+		{"get", "pods", "--run=malicious"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
@@ -533,133 +445,88 @@ func TestFlagInjection(t *testing.T) {
 
 func TestResourceNameConfusion(t *testing.T) {
 	tests := [][]string{
-		// "delete" as a resource name is fine
 		{"get", "delete"},
 		{"describe", "delete"},
 		{"get", "pods", "delete"},
-		// Trying to abuse -f flag
 		{"get", "-f", "/etc/passwd"},
 		{"diff", "-f", "http://evil.com/payload.yaml"},
 		{"get", "-f", "-"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
 func TestExecDisguisedAsGet(t *testing.T) {
-	// Direct exec is blocked
 	assertBlocked(t, []string{"exec", "pod", "--", "bash"})
-	// exec as argument to get is just a resource name
 	assertAllowed(t, []string{"get", "exec"})
 }
 
-// =============================================================================
-// Security Bypass Tests - Plugin Hijacking
-// =============================================================================
-
 func TestKrewReadOnlyAllowed(t *testing.T) {
-	assertAllowed(t, []string{"krew", "list"})
-	assertAllowed(t, []string{"krew", "search"})
-	assertAllowed(t, []string{"krew", "search", "ctx"})
-	assertAllowed(t, []string{"krew", "info", "ctx"})
+	tests := [][]string{
+		{"krew", "list"},
+		{"krew", "search"},
+		{"krew", "search", "ctx"},
+		{"krew", "info", "ctx"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			assertAllowed(t, args)
+		})
+	}
 }
 
 func TestPluginCommands(t *testing.T) {
 	tests := [][]string{
-		// Direct plugin invocation attempts
 		{"plugin", "list"},
-		// Krew (plugin manager) commands - write/install operations
 		{"krew", "install", "ctx"},
 		{"krew", "update"},
 		{"krew", "upgrade"},
 		{"krew", "uninstall", "ctx"},
-		// Commands that look like plugins
 		{"ctx", "production"},
 		{"ns", "kube-system"},
 		{"neat", "get", "pods"},
 		{"tree", "deployment", "nginx"},
 		{"whoami"},
 		{"access-matrix"},
-		// Sneaky plugin-looking commands
 		{"kubectl-delete", "pods"},
 		{"--plugin=delete", "pods"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0], func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
 }
-
-// =============================================================================
-// Security Bypass Tests - Subcommand Smuggling
-// =============================================================================
-
-func TestSubcommandPositionConfusion(t *testing.T) {
-	tests := [][]string{
-		{"config", "", "set-context", "evil"},
-		{"config", " ", "set-context", "evil"},
-		{"config", "--help", "set-context", "evil"},
-		{"rollout", "-n", "default", "restart", "deployment/nginx"},
-	}
-
-	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(_ *testing.T) {
-			// These should be blocked because the actual subcommand parsed is dangerous
-			// or the command structure is invalid
-			_ = kubepolicy.Check(args) // Ensure no panic
-		})
-	}
-}
-
-// =============================================================================
-// Security Bypass Tests - Experimental Commands
-// =============================================================================
 
 func TestExperimentalCommands(t *testing.T) {
 	tests := [][]string{
 		{"alpha"},
 		{"alpha", "something"},
 		{"alpha", "events"},
-		// Debug commands
 		{"debug", "pod/nginx"},
 		{"debug", "-it", "pod/nginx", "--image=busybox"},
-		// Experimental features
 		{"convert", "-f", "pod.yaml"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0], func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
 }
-
-// =============================================================================
-// Security Bypass Tests - Network Commands
-// =============================================================================
 
 func TestNetworkCommands(t *testing.T) {
 	tests := [][]string{
-		// Proxy opens network connections
 		{"proxy"},
 		{"proxy", "--port=8080"},
 		{"proxy", "--www=/"},
-		// Port-forward
 		{"port-forward", "pod/nginx", "8080:80"},
 		{"port-forward", "svc/nginx", "8080:80"},
-		// Attach (interactive)
 		{"attach", "pod/nginx"},
 		{"attach", "-it", "pod/nginx"},
 	}
-
 	for _, args := range tests {
 		t.Run(args[0], func(t *testing.T) {
 			assertBlocked(t, args)
@@ -667,109 +534,74 @@ func TestNetworkCommands(t *testing.T) {
 	}
 }
 
-// =============================================================================
-// Security Bypass Tests - Path Traversal
-// =============================================================================
-
 func TestPathTraversalAndFiles(t *testing.T) {
 	tests := [][]string{
-		// Path traversal in -f flag
 		{"get", "-f", "../../../etc/passwd"},
 		{"get", "-f", "/etc/passwd"},
 		{"diff", "-f", "../../secret.yaml"},
-		// URL in -f flag
 		{"get", "-f", "http://evil.com/payload.yaml"},
 		{"get", "-f", "https://evil.com/payload.yaml"},
-		// Kustomize directory traversal
 		{"get", "-k", "../../"},
 		{"get", "-k", "/etc/kubernetes/"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
-			// These are allowed - kubectl will handle file validation
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
-// =============================================================================
-// Security Bypass Tests - RBAC
-// =============================================================================
-
 func TestRBACInfoGathering(t *testing.T) {
 	tests := [][]string{
-		// auth can-i to probe permissions
 		{"auth", "can-i", "create", "deployments"},
 		{"auth", "can-i", "delete", "secrets"},
 		{"auth", "can-i", "--list"},
 		{"auth", "can-i", "*", "*"},
-		// Getting RBAC resources
 		{"get", "roles"},
 		{"get", "rolebindings"},
 		{"get", "clusterroles"},
 		{"get", "clusterrolebindings"},
 		{"get", "serviceaccounts"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
 func TestImpersonation(t *testing.T) {
-	// Impersonation flags are passed through (RBAC handles it)
 	tests := [][]string{
 		{"get", "pods", "--as=admin"},
 		{"get", "pods", "--as-group=system:masters"},
 		{"auth", "can-i", "get", "pods", "--as=admin"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
-// =============================================================================
-// Security Bypass Tests - Special Resources
-// =============================================================================
-
 func TestSpecialResources(t *testing.T) {
 	tests := [][]string{
-		// API resources that might be dangerous to even read
 		{"get", "mutatingwebhookconfigurations"},
 		{"get", "validatingwebhookconfigurations"},
 		{"get", "certificatesigningrequests"},
-		// CRDs
 		{"get", "crds"},
 		{"get", "customresourcedefinitions"},
-		// Nodes
 		{"get", "nodes"},
 		{"describe", "node", "master-1"},
 		{"top", "nodes"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
-// =============================================================================
-// Security Bypass Tests - Output Formats
-// =============================================================================
-
 func TestOutputFormats(t *testing.T) {
-	// Non-secret resources can use any format
 	tests := [][]string{
 		{"get", "pods", "-o", "yaml"},
 		{"get", "pods", "-o", "json"},
@@ -778,39 +610,26 @@ func TestOutputFormats(t *testing.T) {
 		{"get", "pods", "--template", "/etc/passwd"},
 		{"get", "pods", "-o", "template", "--template=/etc/passwd"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
-
-// =============================================================================
-// Security Bypass Tests - Combined Attacks
-// =============================================================================
 
 func TestCombinedAttacks(t *testing.T) {
 	tests := []struct {
 		args    []string
 		allowed bool
 	}{
-		// Unicode + shell metacharacter
-		{[]string{"get", "pods\u200b;", "delete", "pods"}, true}, // get is command
-		// Flag injection + dangerous command
+		{[]string{"get", "pods\u200b;", "delete", "pods"}, true},
 		{[]string{"--namespace=default", "-o", "yaml", "delete", "pods"}, false},
-		// Subcommand confusion + Unicode
 		{[]string{"config", "set\u200b-context", "evil"}, false},
-		// Long input + metacharacter
-		{[]string{"get", strings.Repeat("a", 1000) + ";delete", "pods"}, true}, // get is command
-		// Multiple dangerous attempts
+		{[]string{"get", strings.Repeat("a", 1000) + ";delete", "pods"}, true},
 		{[]string{"exec", "-it", "pod", "--", "rm", "-rf", "/"}, false},
 	}
-
 	for _, tt := range tests {
-		name := tt.args[0]
-		t.Run(name, func(t *testing.T) {
+		t.Run(tt.args[0], func(t *testing.T) {
 			if tt.allowed {
 				assertAllowed(t, tt.args)
 			} else {
@@ -819,10 +638,6 @@ func TestCombinedAttacks(t *testing.T) {
 		})
 	}
 }
-
-// =============================================================================
-// Context Switching Tests
-// =============================================================================
 
 func TestContextCommands(t *testing.T) {
 	allowed := [][]string{
@@ -834,29 +649,20 @@ func TestContextCommands(t *testing.T) {
 		{"config", "get-users"},
 		{"config", "view"},
 	}
-
 	blocked := [][]string{
 		{"config", "set", "current-context", "production"},
 	}
-
 	for _, args := range allowed {
-		name := "allowed_" + strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run("allowed_"+strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
-
 	for _, args := range blocked {
-		name := "blocked_" + strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run("blocked_"+strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
 }
-
-// =============================================================================
-// Wait and Diff Commands
-// =============================================================================
 
 func TestWaitCommand(t *testing.T) {
 	tests := [][]string{
@@ -865,10 +671,8 @@ func TestWaitCommand(t *testing.T) {
 		{"wait", "--for=delete", "pod/nginx"},
 		{"wait", "--for=condition=Ready", "--timeout=60s", "pod/nginx"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
@@ -879,30 +683,17 @@ func TestDiffCommand(t *testing.T) {
 		{"diff", "-f", "deployment.yaml"},
 		{"diff", "--server-side", "-f", "deployment.yaml"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
 }
 
-// =============================================================================
-// Completion and Help
-// =============================================================================
-
 func TestCompletionBlocked(t *testing.T) {
-	tests := [][]string{
-		{"completion", "bash"},
-		{"completion", "zsh"},
-		{"completion", "fish"},
-		{"completion", "powershell"},
-	}
-
-	for _, args := range tests {
-		t.Run(args[1], func(t *testing.T) {
-			assertBlocked(t, args)
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			assertBlocked(t, []string{"completion", shell})
 		})
 	}
 }
@@ -913,24 +704,15 @@ func TestHelpBlocked(t *testing.T) {
 		{"help", "get"},
 		{"help", "delete"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
 }
 
-// =============================================================================
-// Edge Cases
-// =============================================================================
-
 func TestEmptyAndMalformedInput(t *testing.T) {
-	// Empty string as command - treated as empty args (shows help)
 	assertAllowed(t, []string{""})
-
-	// Whitespace as command - not a valid command, blocked
 	assertBlocked(t, []string{" "})
 	assertBlocked(t, []string{"  "})
 	assertBlocked(t, []string{"\t"})
@@ -939,15 +721,11 @@ func TestEmptyAndMalformedInput(t *testing.T) {
 }
 
 func TestLongInput(t *testing.T) {
-	// Very long resource name - still allowed if command is safe
 	longName := strings.Repeat("a", 10000)
 	assertAllowed(t, []string{"get", longName})
 	assertAllowed(t, []string{"get", "pods", "-n", longName})
-
-	// Very long unknown command - blocked
 	assertBlocked(t, []string{longName})
 
-	// Many arguments
 	manyArgs := append([]string{"get", "pods"}, make([]string, 1000)...)
 	for i := 2; i < len(manyArgs); i++ {
 		manyArgs[i] = "arg"
@@ -956,7 +734,7 @@ func TestLongInput(t *testing.T) {
 }
 
 // =============================================================================
-// Kustomize Command Tests
+// Kustomize Tests
 // =============================================================================
 
 func TestKustomizeAllowed(t *testing.T) {
@@ -970,10 +748,8 @@ func TestKustomizeAllowed(t *testing.T) {
 		{"-n", "default", "kustomize", "."},
 		{"--context=prod", "kustomize", "/path"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertAllowed(t, args)
 		})
 	}
@@ -988,18 +764,6 @@ func TestKustomizeBlockedFlags(t *testing.T) {
 		{"kustomize", "--load-restrictor", "None", "."},
 		{"kustomize", "--load-restrictor", "LoadRestrictionsNone", "."},
 		{"kustomize", "--load-restrictor=LoadRestrictionsNone", "."},
-	}
-
-	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
-			assertBlocked(t, args)
-		})
-	}
-}
-
-func TestKustomizeBlockedFlagVariations(t *testing.T) {
-	tests := [][]string{
 		{"kustomize", "--enable-alpha-plugins=true", "."},
 		{"kustomize", "--enable-helm=true", "."},
 		{"kustomize", "--network=true", "."},
@@ -1008,23 +772,155 @@ func TestKustomizeBlockedFlagVariations(t *testing.T) {
 		{"kustomize", ".", "--network"},
 		{"kustomize", ".", "--enable-alpha-plugins"},
 	}
-
 	for _, args := range tests {
-		name := strings.Join(args, "_")
-		t.Run(name, func(t *testing.T) {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			assertBlocked(t, args)
 		})
 	}
 }
 
-func TestKustomizeLoadRestrictorDefault(t *testing.T) {
-	// Default value is allowed
-	assertAllowed(t, []string{"kustomize", "--load-restrictor=LoadRestrictionsRootOnly", "."})
-	assertAllowed(t, []string{"kustomize", "--load-restrictor", "LoadRestrictionsRootOnly", "."})
+// =============================================================================
+// Helper Function Tests
+// =============================================================================
 
-	// Non-default values are blocked
-	assertBlocked(t, []string{"kustomize", "--load-restrictor=None", "."})
-	assertBlocked(t, []string{"kustomize", "--load-restrictor", "None", "."})
-	assertBlocked(t, []string{"kustomize", "--load-restrictor=LoadRestrictionsNone", "."})
-	assertBlocked(t, []string{"kustomize", "--load-restrictor", "LoadRestrictionsNone", "."})
+func TestExtractCommandAndSubcommand(t *testing.T) {
+	tests := []struct {
+		args       []string
+		command    string
+		subcommand string
+	}{
+		{[]string{"get", "pods"}, "get", "pods"},
+		{[]string{"-n", "default", "get", "pods"}, "get", "pods"},
+		{[]string{"--namespace=default", "get", "pods"}, "get", "pods"},
+		{[]string{"config", "view"}, "config", "view"},
+		{[]string{"rollout", "status", "deploy/nginx"}, "rollout", "status"},
+		{[]string{"-o", "yaml", "get", "pods"}, "get", "pods"},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			cmd, sub := extractCommandAndSubcommand(tt.args)
+			if cmd != tt.command {
+				t.Errorf("command: got %q, want %q", cmd, tt.command)
+			}
+			if sub != tt.subcommand {
+				t.Errorf("subcommand: got %q, want %q", sub, tt.subcommand)
+			}
+		})
+	}
+}
+
+func TestExtractResourceTypes(t *testing.T) {
+	tests := []struct {
+		args      []string
+		resources []string
+	}{
+		{[]string{"get", "pods"}, []string{"pods"}},
+		{[]string{"get", "pods,secrets"}, []string{"pods", "secrets"}},
+		{[]string{"get", "secret/my-secret"}, []string{"secret"}},
+		{[]string{"-n", "default", "get", "pods"}, []string{"pods"}},
+		{[]string{"delete", "pods"}, nil},
+		{[]string{"get", "secret.v1"}, []string{"secret"}},
+		{[]string{"get", "secrets.v1"}, []string{"secrets"}},
+		{[]string{"get", "secret.core"}, []string{"secret"}},
+		{[]string{"get", "secret.v1.core"}, []string{"secret"}},
+		{[]string{"get", "secret.v1/my-secret"}, []string{"secret"}},
+		{[]string{"get", "pods.v1,secret.core"}, []string{"pods", "secret"}},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			got := extractResourceTypes(tt.args)
+			if len(got) != len(tt.resources) {
+				t.Errorf("got %v, want %v", got, tt.resources)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.resources[i] {
+					t.Errorf("got %v, want %v", got, tt.resources)
+				}
+			}
+		})
+	}
+}
+
+func TestGetOutputFormat(t *testing.T) {
+	tests := []struct {
+		args   []string
+		format string
+	}{
+		{[]string{"get", "pods", "-o", "yaml"}, "yaml"},
+		{[]string{"get", "pods", "-o=yaml"}, "yaml"},
+		{[]string{"get", "pods", "-oyaml"}, "yaml"},
+		{[]string{"get", "pods", "--output", "json"}, "json"},
+		{[]string{"get", "pods", "--output=json"}, "json"},
+		{[]string{"get", "pods"}, ""},
+	}
+	for _, tt := range tests {
+		name := tt.format
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			got := getOutputFormat(tt.args)
+			if got != tt.format {
+				t.Errorf("got %q, want %q", got, tt.format)
+			}
+		})
+	}
+}
+
+func TestIsSecretExposingFormat(t *testing.T) {
+	exposing := []string{
+		"yaml", "json", "jsonpath", "jsonpath={.data}",
+		"jsonpath-as-json", "jsonpath-file",
+		"go-template", "go-template={{.data}}", "go-template-file",
+		"template", "templatefile",
+		"custom-columns", "custom-columns=NAME:.metadata.name", "custom-columns-file",
+	}
+	safe := []string{"", "name", "wide"}
+	for _, f := range exposing {
+		t.Run("exposing_"+f, func(t *testing.T) {
+			if !isSecretExposingFormat(f) {
+				t.Errorf("%q should be exposing", f)
+			}
+		})
+	}
+	for _, f := range safe {
+		name := f
+		if name == "" {
+			name = "empty"
+		}
+		t.Run("safe_"+name, func(t *testing.T) {
+			if isSecretExposingFormat(f) {
+				t.Errorf("%q should be safe", f)
+			}
+		})
+	}
+}
+
+func TestContainsRawSecretsAccess(t *testing.T) {
+	blocked := [][]string{
+		{"get", "--raw", "/api/v1/secrets"},
+		{"get", "--raw=/api/v1/secrets"},
+		{"get", "--raw", "/api/v1/namespaces/default/secrets"},
+		{"get", "--raw", "/api/v1/namespaces/default/secrets/my-secret"},
+	}
+	allowed := [][]string{
+		{"get", "--raw", "/api/v1/pods"},
+		{"get", "--raw", "/healthz"},
+		{"get", "pods"},
+	}
+	for _, args := range blocked {
+		t.Run("blocked_"+strings.Join(args, "_"), func(t *testing.T) {
+			if !containsRawSecretsAccess(args) {
+				t.Errorf("expected raw secrets access detected: %v", args)
+			}
+		})
+	}
+	for _, args := range allowed {
+		t.Run("allowed_"+strings.Join(args, "_"), func(t *testing.T) {
+			if containsRawSecretsAccess(args) {
+				t.Errorf("expected no raw secrets access: %v", args)
+			}
+		})
+	}
 }

--- a/kubepolicy/parse.go
+++ b/kubepolicy/parse.go
@@ -1,0 +1,171 @@
+package kubepolicy
+
+import "strings"
+
+func extractCommandAndSubcommand(args []string) (command, subcommand string) {
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+
+		if strings.HasPrefix(arg, "-") {
+			if strings.Contains(arg, "=") {
+				i++
+			} else if flagsWithValues[arg] {
+				i += 2
+			} else {
+				i++
+			}
+			continue
+		}
+
+		if command == "" {
+			command = arg
+			i++
+		} else if subcommand == "" {
+			subcommand = arg
+			break
+		} else {
+			break
+		}
+	}
+	return
+}
+
+func extractResourceTypes(args []string) []string {
+	command, _ := extractCommandAndSubcommand(args)
+	if command != "get" && command != "describe" && command != "wait" && command != "events" {
+		return nil
+	}
+
+	var resources []string
+	foundCommand := false
+	i := 0
+
+	for i < len(args) {
+		arg := args[i]
+
+		if strings.HasPrefix(arg, "-") {
+			if strings.Contains(arg, "=") {
+				i++
+			} else if flagsWithValues[arg] {
+				i += 2
+			} else {
+				i++
+			}
+			continue
+		}
+
+		if !foundCommand {
+			if arg == command {
+				foundCommand = true
+			}
+			i++
+			continue
+		}
+
+		for _, part := range strings.Split(arg, ",") {
+			resourceType := part
+			if idx := strings.Index(part, "/"); idx != -1 {
+				resourceType = part[:idx]
+			}
+			// Strip API group qualifiers (e.g. secret.v1, secret.v1.core)
+			if idx := strings.Index(resourceType, "."); idx != -1 {
+				resourceType = resourceType[:idx]
+			}
+			resourceType = strings.ToLower(resourceType)
+			if resourceType != "" && !strings.HasPrefix(resourceType, "-") {
+				resources = append(resources, resourceType)
+			}
+		}
+		i++
+	}
+
+	return resources
+}
+
+func containsSecretResource(args []string) bool {
+	for _, r := range extractResourceTypes(args) {
+		if secretResources[r] {
+			return true
+		}
+	}
+	return false
+}
+
+func getOutputFormat(args []string) string {
+	for i, arg := range args {
+		if (arg == "-o" || arg == "--output") && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(arg, "-o=") {
+			return arg[3:]
+		}
+		if strings.HasPrefix(arg, "--output=") {
+			return arg[9:]
+		}
+		if strings.HasPrefix(arg, "-o") && len(arg) > 2 {
+			return arg[2:]
+		}
+	}
+	return ""
+}
+
+func isSecretExposingFormat(format string) bool {
+	if format == "" {
+		return false
+	}
+	format = strings.ToLower(format)
+	for exposing := range secretExposingFormats {
+		if format == exposing || strings.HasPrefix(format, exposing+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRawSecretsAccess(args []string) bool {
+	var rawValue string
+	for i, arg := range args {
+		if arg == "--raw" && i+1 < len(args) {
+			rawValue = args[i+1]
+			break
+		}
+		if strings.HasPrefix(arg, "--raw=") {
+			rawValue = arg[6:]
+			break
+		}
+	}
+
+	if rawValue == "" {
+		return false
+	}
+
+	rawLower := strings.ToLower(rawValue)
+	return strings.Contains(rawLower, "/secrets") ||
+		strings.Contains(rawLower, "/secret/") ||
+		strings.Contains(rawLower, "secrets/")
+}
+
+func containsBlockedKustomizeFlags(args []string) bool {
+	for i, arg := range args {
+		if kustomizeBlockedFlags[arg] {
+			return true // deny: blocked kustomize flag
+		}
+		for flag := range kustomizeBlockedFlags {
+			if strings.HasPrefix(arg, flag+"=") {
+				return true // deny: blocked kustomize flag with value
+			}
+		}
+		// --load-restrictor with non-default value
+		if arg == "--load-restrictor" && i+1 < len(args) && args[i+1] != "LoadRestrictionsRootOnly" {
+			return true // deny: non-default load restrictor
+		}
+		if strings.HasPrefix(arg, "--load-restrictor=") {
+			val := arg[len("--load-restrictor="):]
+			if val != "LoadRestrictionsRootOnly" {
+				return true // deny: non-default load restrictor
+			}
+		}
+	}
+	return false
+}

--- a/kubepolicy/policy.go
+++ b/kubepolicy/policy.go
@@ -1,0 +1,97 @@
+package kubepolicy
+
+// safeCommands are kubectl commands allowed without subcommand validation.
+var safeCommands = map[string]bool{
+	"get":           true,
+	"describe":      true,
+	"logs":          true,
+	"top":           true,
+	"explain":       true,
+	"api-resources": true,
+	"api-versions":  true,
+	"cluster-info":  true,
+	"version":       true,
+	"events":        true,
+	"wait":          true,
+	"diff":          true,
+	"kustomize":     true,
+}
+
+// safeSubcommands are kubectl commands that require a specific subcommand.
+var safeSubcommands = map[string]map[string]bool{
+	"config": {
+		"view":            true,
+		"get-contexts":    true,
+		"get-clusters":    true,
+		"get-users":       true,
+		"current-context": true,
+		"use-context":     true,
+	},
+	"auth": {
+		"can-i":  true,
+		"whoami": true,
+	},
+	"rollout": {
+		"status":  true,
+		"history": true,
+	},
+	"krew": {
+		"list":   true,
+		"search": true,
+		"info":   true,
+	},
+}
+
+// secretResources are resource types that contain sensitive data.
+var secretResources = map[string]bool{
+	"secret":  true,
+	"secrets": true,
+}
+
+// secretExposingFormats are output formats that expose secret values.
+var secretExposingFormats = map[string]bool{
+	"yaml":                true,
+	"json":                true,
+	"jsonpath":            true,
+	"jsonpath-as-json":    true,
+	"jsonpath-file":       true,
+	"go-template":         true,
+	"go-template-file":    true,
+	"template":            true,
+	"templatefile":        true,
+	"custom-columns":      true,
+	"custom-columns-file": true,
+}
+
+// flagsWithValues are kubectl flags that consume the next argument.
+var flagsWithValues = map[string]bool{
+	"-n": true, "--namespace": true,
+	"--context": true, "--kubeconfig": true,
+	"-o": true, "--output": true,
+	"-l": true, "--selector": true,
+	"--field-selector": true,
+	"-v":               true, "--v": true,
+	"--request-timeout": true,
+	"--server":          true, "-s": true,
+	"--token": true, "--user": true, "--cluster": true,
+	"--certificate-authority": true,
+	"--client-certificate":    true, "--client-key": true,
+	"--tls-server-name": true,
+	"--as":              true, "--as-group": true, "--as-uid": true,
+	"--cache-dir": true, "--sort-by": true, "--chunk-size": true,
+	"--template": true,
+	"-f":         true, "--filename": true,
+	"-k": true, "--kustomize": true,
+	"--since": true, "--since-time": true, "--tail": true,
+	"-c": true, "--container": true,
+	"--limit-bytes": true, "--pod-running-timeout": true,
+	"--timeout": true, "--for": true, "--max-log-requests": true,
+}
+
+// kustomizeBlockedFlags are flags that enable code execution, network access,
+// or unrestricted file reads when used with the kustomize command.
+var kustomizeBlockedFlags = map[string]bool{
+	"--enable-alpha-plugins": true,
+	"--enable-helm":          true,
+	"--network":              true,
+}

--- a/kubepolicy/sanitize.go
+++ b/kubepolicy/sanitize.go
@@ -1,0 +1,19 @@
+package kubepolicy
+
+func containsControlCharacters(args []string) bool {
+	for _, arg := range args {
+		for _, r := range arg {
+			// Block null byte and other dangerous control characters.
+			// Allow common whitespace: tab (0x09), newline (0x0A), carriage return (0x0D).
+			if r == 0x00 ||
+				(r >= 0x01 && r <= 0x08) ||
+				(r >= 0x0E && r <= 0x1F) ||
+				r == 0x0B ||
+				r == 0x0C ||
+				r == 0x7F {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
+
+	"github.com/Evaneos/kubectl-readonly/kubepolicy"
 )
 
 const (
@@ -51,25 +52,23 @@ func run(args []string) int {
 	}
 
 	// Validate the command
-	allowed, reason := isCommandAllowed(filteredArgs)
+	allowed := kubepolicy.Check(filteredArgs)
 
 	if checkMode {
 		if allowed {
 			fmt.Println("OK: This command is allowed by kubectl-readonly")
 			return 0
 		}
-		fmt.Printf("BLOCKED: %s\n", reason)
+		fmt.Println("BLOCKED: This command is not allowed in read-only mode")
 		return 1
 	}
 
 	if !allowed {
-		fmt.Fprintf(os.Stderr, `This command is not safe for read-only access; use kubectl directly instead.
-
-Reason: %s
+		fmt.Fprint(os.Stderr, `This command is not safe for read-only access; use kubectl directly instead.
 
 kubectl-readonly only allows read-only commands without side effects.
 For a list of allowed commands, see: kubectl-readonly --help
-`, reason)
+`)
 		return 1
 	}
 
@@ -120,10 +119,11 @@ ALLOWED COMMANDS:
         cluster-info, version, events, wait, diff, kustomize
 
     Commands with specific subcommands:
-        config view, config get-contexts, config current-context,
-        config use-context
+        config view, config get-contexts, config get-clusters,
+        config get-users, config current-context, config use-context
         auth can-i, auth whoami
         rollout status, rollout history
+        krew list, krew search, krew info
 
 KUSTOMIZE RESTRICTIONS:
     The kustomize command is allowed for local manifest rendering, but
@@ -157,349 +157,4 @@ ALIAS:
     Or use as a kubectl plugin (if installed via Krew):
         kubectl readonly get pods
 `)
-}
-
-// Safe commands that don't require subcommand validation
-var safeCommands = map[string]bool{
-	"get":           true,
-	"describe":      true,
-	"logs":          true,
-	"top":           true,
-	"explain":       true,
-	"api-resources": true,
-	"api-versions":  true,
-	"cluster-info":  true,
-	"version":       true,
-	"events":        true,
-	"wait":          true,
-	"diff":          true,
-	"kustomize":     true,
-}
-
-// Commands with allowed subcommands
-var safeSubcommands = map[string]map[string]bool{
-	"config": {
-		"view":            true,
-		"get-contexts":    true,
-		"current-context": true,
-		"use-context":     true,
-	},
-	"auth": {
-		"can-i":  true,
-		"whoami": true,
-	},
-	"rollout": {
-		"status":  true,
-		"history": true,
-	},
-}
-
-// Secret resource types
-var secretResources = map[string]bool{
-	"secret":  true,
-	"secrets": true,
-}
-
-// Output formats that expose secret values
-var secretExposingFormats = map[string]bool{
-	"yaml":                true,
-	"json":                true,
-	"jsonpath":            true,
-	"jsonpath-as-json":    true,
-	"jsonpath-file":       true,
-	"go-template":         true,
-	"go-template-file":    true,
-	"template":            true,
-	"templatefile":        true,
-	"custom-columns":      true,
-	"custom-columns-file": true,
-}
-
-// Flags that take a value as the next argument
-var flagsWithValues = map[string]bool{
-	"-n": true, "--namespace": true,
-	"--context": true, "--kubeconfig": true,
-	"-o": true, "--output": true,
-	"-l": true, "--selector": true,
-	"--field-selector": true,
-	"-v":               true, "--v": true,
-	"--request-timeout": true,
-	"--server":          true, "-s": true,
-	"--token": true, "--user": true, "--cluster": true,
-	"--certificate-authority": true,
-	"--client-certificate":    true, "--client-key": true,
-	"--tls-server-name": true,
-	"--as":              true, "--as-group": true, "--as-uid": true,
-	"--cache-dir": true, "--sort-by": true, "--chunk-size": true,
-	"--template": true,
-	"-f":         true, "--filename": true,
-	"-k": true, "--kustomize": true,
-	"--since": true, "--since-time": true, "--tail": true,
-	"-c": true, "--container": true,
-	"--limit-bytes": true, "--pod-running-timeout": true,
-	"--timeout": true, "--for": true, "--max-log-requests": true,
-}
-
-func isCommandAllowed(args []string) (bool, string) {
-	if len(args) == 0 {
-		return true, ""
-	}
-
-	// Check for control characters (null bytes, etc.) - potential injection attack
-	if containsControlCharacters(args) {
-		return false, "Arguments contain invalid control characters"
-	}
-
-	command, subcommand := extractCommandAndSubcommand(args)
-	if command == "" {
-		return true, ""
-	}
-
-	// Check safe commands
-	if safeCommands[command] {
-		// Check secrets protection
-		if containsSecretResource(args) {
-			outputFormat := getOutputFormat(args)
-			if isSecretExposingFormat(outputFormat) {
-				return false, fmt.Sprintf("Output format '%s' exposes secret values. Use default format or '-o name' to see secret metadata only.", outputFormat)
-			}
-		}
-
-		// Check --raw access to secrets
-		if containsRawSecretsAccess(args) {
-			return false, "Access to secrets via --raw is not allowed (exposes secret values)"
-		}
-
-		// Check kustomize-specific blocked flags
-		if command == "kustomize" {
-			if blocked, reason := containsBlockedKustomizeFlags(args); blocked {
-				return false, reason
-			}
-		}
-
-		return true, ""
-	}
-
-	// Check commands with subcommands
-	if allowedSubs, ok := safeSubcommands[command]; ok {
-		if subcommand == "" {
-			var allowed []string
-			for k := range allowedSubs {
-				allowed = append(allowed, k)
-			}
-			return false, fmt.Sprintf("Command '%s' requires a subcommand. Allowed: %s", command, strings.Join(allowed, ", "))
-		}
-		if allowedSubs[subcommand] {
-			return true, ""
-		}
-		var allowed []string
-		for k := range allowedSubs {
-			allowed = append(allowed, k)
-		}
-		return false, fmt.Sprintf("Subcommand '%s %s' is not allowed. Allowed subcommands for '%s': %s", command, subcommand, command, strings.Join(allowed, ", "))
-	}
-
-	return false, fmt.Sprintf("Command '%s' is not in the read-only allowlist", command)
-}
-
-func extractCommandAndSubcommand(args []string) (command, subcommand string) {
-	i := 0
-	for i < len(args) {
-		arg := args[i]
-
-		if strings.HasPrefix(arg, "-") {
-			// Skip flag and its value if applicable
-			if strings.Contains(arg, "=") {
-				i++
-			} else if flagsWithValues[arg] {
-				i += 2
-			} else {
-				i++
-			}
-			continue
-		}
-
-		// Positional argument
-		if command == "" {
-			command = arg
-			i++
-		} else if subcommand == "" {
-			subcommand = arg
-			break
-		} else {
-			break
-		}
-	}
-	return
-}
-
-func extractResourceTypes(args []string) []string {
-	command, _ := extractCommandAndSubcommand(args)
-	if command != "get" && command != "describe" && command != "wait" && command != "events" {
-		return nil
-	}
-
-	var resources []string
-	foundCommand := false
-	i := 0
-
-	for i < len(args) {
-		arg := args[i]
-
-		if strings.HasPrefix(arg, "-") {
-			if strings.Contains(arg, "=") {
-				i++
-			} else if flagsWithValues[arg] {
-				i += 2
-			} else {
-				i++
-			}
-			continue
-		}
-
-		if !foundCommand {
-			if arg == command {
-				foundCommand = true
-			}
-			i++
-			continue
-		}
-
-		// Parse resource types (handles comma-separated, type/name, and type.group formats)
-		for _, part := range strings.Split(arg, ",") {
-			resourceType := part
-			if idx := strings.Index(part, "/"); idx != -1 {
-				resourceType = part[:idx]
-			}
-			// Strip API group qualifiers (e.g., secret.v1, secret.v1.core, secrets.core)
-			if idx := strings.Index(resourceType, "."); idx != -1 {
-				resourceType = resourceType[:idx]
-			}
-			resourceType = strings.ToLower(resourceType)
-			if resourceType != "" && !strings.HasPrefix(resourceType, "-") {
-				resources = append(resources, resourceType)
-			}
-		}
-		i++
-	}
-
-	return resources
-}
-
-func containsSecretResource(args []string) bool {
-	for _, r := range extractResourceTypes(args) {
-		if secretResources[r] {
-			return true
-		}
-	}
-	return false
-}
-
-func getOutputFormat(args []string) string {
-	for i, arg := range args {
-		if (arg == "-o" || arg == "--output") && i+1 < len(args) {
-			return args[i+1]
-		}
-		if strings.HasPrefix(arg, "-o=") {
-			return arg[3:]
-		}
-		if strings.HasPrefix(arg, "--output=") {
-			return arg[9:]
-		}
-		if strings.HasPrefix(arg, "-o") && len(arg) > 2 {
-			return arg[2:]
-		}
-	}
-	return ""
-}
-
-func isSecretExposingFormat(format string) bool {
-	if format == "" {
-		return false
-	}
-	format = strings.ToLower(format)
-	for exposing := range secretExposingFormats {
-		if format == exposing || strings.HasPrefix(format, exposing+"=") {
-			return true
-		}
-	}
-	return false
-}
-
-func containsRawSecretsAccess(args []string) bool {
-	var rawValue string
-	for i, arg := range args {
-		if arg == "--raw" && i+1 < len(args) {
-			rawValue = args[i+1]
-			break
-		}
-		if strings.HasPrefix(arg, "--raw=") {
-			rawValue = arg[6:]
-			break
-		}
-	}
-
-	if rawValue == "" {
-		return false
-	}
-
-	rawLower := strings.ToLower(rawValue)
-	return strings.Contains(rawLower, "/secrets") ||
-		strings.Contains(rawLower, "/secret/") ||
-		strings.Contains(rawLower, "secrets/")
-}
-
-// Flags blocked for the kustomize command.
-// kustomize is a local build tool (no cluster interaction), but these flags
-// enable code execution, network access, or unrestricted file reads — actions
-// that should require explicit user approval via kubectl directly.
-var kustomizeBlockedFlags = map[string]bool{
-	"--enable-alpha-plugins": true,
-	"--enable-helm":          true,
-	"--network":              true,
-}
-
-func containsBlockedKustomizeFlags(args []string) (bool, string) {
-	for i, arg := range args {
-		// Exact match: --enable-helm, --network
-		if kustomizeBlockedFlags[arg] {
-			return true, fmt.Sprintf("Flag '%s' is not allowed with kustomize in read-only mode", arg)
-		}
-		// Boolean flag with =true: --enable-helm=true, --network=true
-		for flag := range kustomizeBlockedFlags {
-			if strings.HasPrefix(arg, flag+"=") {
-				return true, fmt.Sprintf("Flag '%s' is not allowed with kustomize in read-only mode", flag)
-			}
-		}
-		// --load-restrictor with non-default value
-		if arg == "--load-restrictor" && i+1 < len(args) && args[i+1] != "LoadRestrictionsRootOnly" {
-			return true, "Flag '--load-restrictor' with non-default value is not allowed with kustomize in read-only mode"
-		}
-		if strings.HasPrefix(arg, "--load-restrictor=") {
-			val := arg[len("--load-restrictor="):]
-			if val != "LoadRestrictionsRootOnly" {
-				return true, "Flag '--load-restrictor' with non-default value is not allowed with kustomize in read-only mode"
-			}
-		}
-	}
-	return false, ""
-}
-
-func containsControlCharacters(args []string) bool {
-	for _, arg := range args {
-		for _, r := range arg {
-			// Block null byte and other dangerous control characters
-			// Allow common whitespace (tab=0x09, newline=0x0A, carriage return=0x0D)
-			// These are handled safely by the OS and don't pose injection risks
-			if r == 0x00 || // Null byte - can truncate strings
-				(r >= 0x01 && r <= 0x08) || // SOH to BS
-				(r >= 0x0E && r <= 0x1F) || // SO to US (excluding common whitespace)
-				r == 0x0B || // Vertical tab
-				r == 0x0C || // Form feed
-				r == 0x7F { // DEL character
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -182,6 +182,8 @@ func TestSmoke_Direct_SafeCommands(t *testing.T) {
 		{"diff", "-f", "file.yaml"},
 		{"config", "view"},
 		{"config", "get-contexts"},
+		{"config", "get-clusters"},
+		{"config", "get-users"},
 		{"config", "current-context"},
 		{"config", "use-context", "my-context"},
 		{"auth", "can-i", "get", "pods"},
@@ -192,6 +194,10 @@ func TestSmoke_Direct_SafeCommands(t *testing.T) {
 		{"kustomize", "."},
 		{"kustomize", "/path/to/dir"},
 		{"kustomize", "--load-restrictor=LoadRestrictionsRootOnly", "."},
+		{"krew", "list"},
+		{"krew", "search"},
+		{"krew", "search", "ctx"},
+		{"krew", "info", "ctx"},
 	}
 
 	for _, args := range safeCommands {
@@ -244,6 +250,10 @@ func TestSmoke_Direct_DangerousCommands(t *testing.T) {
 		{"kustomize", "--enable-alpha-plugins", "."},
 		{"kustomize", "--network", "."},
 		{"kustomize", "--load-restrictor=None", "."},
+		{"krew", "install", "ctx"},
+		{"krew", "update"},
+		{"krew", "upgrade"},
+		{"krew", "uninstall", "ctx"},
 	}
 
 	for _, args := range dangerousCommands {
@@ -359,6 +369,8 @@ func TestSmoke_Plugin_SafeCommands(t *testing.T) {
 		{"version", "--client"},
 		{"config", "view"},
 		{"config", "get-contexts"},
+		{"config", "get-clusters"},
+		{"config", "get-users"},
 		{"auth", "can-i", "get", "pods"},
 		{"rollout", "status", "deployment/nginx"},
 	}


### PR DESCRIPTION
## Summary

- Extract policy checking logic into a reusable `kubepolicy/` package with a single exported API: `Check(args []string) bool`
- `main.go` becomes a thin wrapper (~160 lines, down from ~505)
- New allowed commands: `config get-clusters`, `config get-users`, `krew list/search/info`
- Blocked messages simplified to generic (no specific reason string)
- README updated: kustomize restrictions section, new commands in tables, corrected output examples

## Motivation

The policy logic is now importable by other Go projects without code duplication.

## No breaking changes

- Exit codes: unchanged (0 = allowed, 1 = blocked)
- `BLOCKED:` prefix in `--readonly-check-ok`: preserved
- All previously allowed commands: still allowed
- All previously blocked commands: still blocked
- Only change: blocked messages no longer include a specific `Reason:` line

## New allowed commands

| Command | Purpose |
|---|---|
| `config get-clusters` | List configured clusters (read-only) |
| `config get-users` | List configured users (read-only) |
| `krew list` | List installed krew plugins |
| `krew search` | Search available krew plugins |
| `krew info` | Show info about a krew plugin |

`krew install`, `krew update`, `krew upgrade`, `krew uninstall` remain **blocked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)