### PR TITLE
security: block secret value bypass via multiple -o/--output flags

### DIFF
--- a/kubepolicy/check.go
+++ b/kubepolicy/check.go
@@ -28,7 +28,7 @@ func Check(args []string) (bool, string) {
 	// Safe commands (no subcommand validation needed).
 	if safeCommands[command] {
 		if containsSecretResource(args) {
-			if isSecretExposingFormat(getOutputFormat(args)) {
+			if hasSecretExposingOutput(args) {
 				return false, "use -o name or -o wide to view secret metadata safely"
 			}
 		}

--- a/kubepolicy/check_test.go
+++ b/kubepolicy/check_test.go
@@ -216,6 +216,15 @@ func TestSecretsValuesBlocked(t *testing.T) {
 		{"get", "secret.v1/my-secret", "-o", "yaml"},
 		{"get", "pods,secret.v1", "-o", "yaml"},
 		{"get", "secret.core,configmaps", "-o", "json"},
+		// Multiple -o/--output flags: kubectl uses the LAST one,
+		// so any exposing format anywhere in the args must be blocked.
+		{"get", "secrets", "-o", "name", "-o", "yaml"},
+		{"get", "secrets", "-o", "wide", "-o", "json"},
+		{"get", "secrets", "--output", "name", "-o", "yaml"},
+		{"get", "secrets", "-o=name", "--output=yaml"},
+		// Even when the LAST format is safe, kubectl would honour the last
+		// one, but we still block to keep the surface small and predictable.
+		{"get", "secrets", "-o", "yaml", "-o", "name"},
 	}
 	for _, args := range tests {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {
@@ -868,27 +877,63 @@ func TestExtractResourceTypes(t *testing.T) {
 	}
 }
 
-func TestGetOutputFormat(t *testing.T) {
+func TestGetOutputFormats(t *testing.T) {
 	tests := []struct {
-		args   []string
-		format string
+		name    string
+		args    []string
+		formats []string
 	}{
-		{[]string{"get", "pods", "-o", "yaml"}, "yaml"},
-		{[]string{"get", "pods", "-o=yaml"}, "yaml"},
-		{[]string{"get", "pods", "-oyaml"}, "yaml"},
-		{[]string{"get", "pods", "--output", "json"}, "json"},
-		{[]string{"get", "pods", "--output=json"}, "json"},
-		{[]string{"get", "pods"}, ""},
+		{"short", []string{"get", "pods", "-o", "yaml"}, []string{"yaml"}},
+		{"short_eq", []string{"get", "pods", "-o=yaml"}, []string{"yaml"}},
+		{"short_concat", []string{"get", "pods", "-oyaml"}, []string{"yaml"}},
+		{"long", []string{"get", "pods", "--output", "json"}, []string{"json"}},
+		{"long_eq", []string{"get", "pods", "--output=json"}, []string{"json"}},
+		{"none", []string{"get", "pods"}, nil},
+		{"multiple_short", []string{"get", "secrets", "-o", "name", "-o", "yaml"}, []string{"name", "yaml"}},
+		{"multiple_mixed", []string{"get", "secrets", "--output", "name", "-o", "yaml"}, []string{"name", "yaml"}},
+		{"multiple_eq", []string{"get", "secrets", "-o=wide", "--output=json"}, []string{"wide", "json"}},
 	}
 	for _, tt := range tests {
-		name := tt.format
-		if name == "" {
-			name = "empty"
-		}
-		t.Run(name, func(t *testing.T) {
-			got := getOutputFormat(tt.args)
-			if got != tt.format {
-				t.Errorf("got %q, want %q", got, tt.format)
+		t.Run(tt.name, func(t *testing.T) {
+			got := getOutputFormats(tt.args)
+			if len(got) != len(tt.formats) {
+				t.Errorf("got %v, want %v", got, tt.formats)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.formats[i] {
+					t.Errorf("got %v, want %v", got, tt.formats)
+				}
+			}
+		})
+	}
+}
+
+func TestHasSecretExposingOutput(t *testing.T) {
+	exposing := [][]string{
+		{"get", "secrets", "-o", "yaml"},
+		{"get", "secrets", "-o", "name", "-o", "yaml"},
+		{"get", "secrets", "--output", "name", "-o", "yaml"},
+		{"get", "secrets", "-o=wide", "--output=json"},
+		{"get", "secrets", "-o", "yaml", "-o", "name"},
+	}
+	safe := [][]string{
+		{"get", "secrets"},
+		{"get", "secrets", "-o", "name"},
+		{"get", "secrets", "-o", "name", "-o", "wide"},
+		{"get", "secrets", "--output=name"},
+	}
+	for _, args := range exposing {
+		t.Run("exposing_"+strings.Join(args, "_"), func(t *testing.T) {
+			if !hasSecretExposingOutput(args) {
+				t.Errorf("expected exposing output detected: %v", args)
+			}
+		})
+	}
+	for _, args := range safe {
+		t.Run("safe_"+strings.Join(args, "_"), func(t *testing.T) {
+			if hasSecretExposingOutput(args) {
+				t.Errorf("expected no exposing output: %v", args)
 			}
 		})
 	}

--- a/kubepolicy/parse.go
+++ b/kubepolicy/parse.go
@@ -92,22 +92,35 @@ func containsSecretResource(args []string) bool {
 	return false
 }
 
-func getOutputFormat(args []string) string {
+// getOutputFormats returns every -o/--output value present in args.
+// kubectl honours the LAST occurrence when more than one is given, so checking
+// only the first allowed `-o name -o yaml` to bypass secret protection.
+func getOutputFormats(args []string) []string {
+	var formats []string
 	for i, arg := range args {
-		if (arg == "-o" || arg == "--output") && i+1 < len(args) {
-			return args[i+1]
-		}
-		if strings.HasPrefix(arg, "-o=") {
-			return arg[3:]
-		}
-		if strings.HasPrefix(arg, "--output=") {
-			return arg[9:]
-		}
-		if strings.HasPrefix(arg, "-o") && len(arg) > 2 {
-			return arg[2:]
+		switch {
+		case (arg == "-o" || arg == "--output") && i+1 < len(args):
+			formats = append(formats, args[i+1])
+		case strings.HasPrefix(arg, "-o="):
+			formats = append(formats, arg[3:])
+		case strings.HasPrefix(arg, "--output="):
+			formats = append(formats, arg[9:])
+		case strings.HasPrefix(arg, "-o") && len(arg) > 2:
+			formats = append(formats, arg[2:])
 		}
 	}
-	return ""
+	return formats
+}
+
+// hasSecretExposingOutput reports whether any -o/--output flag in args
+// requests a format that would expose secret values.
+func hasSecretExposingOutput(args []string) bool {
+	for _, f := range getOutputFormats(args) {
+		if isSecretExposingFormat(f) {
+			return true
+		}
+	}
+	return false
 }
 
 func isSecretExposingFormat(format string) bool {


### PR DESCRIPTION
See this issue: https://github.com/Evaneos/kubectl-readonly/issues/16